### PR TITLE
Remove assert

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,11 +52,6 @@
 
 - name: Ensure ARK server running
   service: name=arkmanager state=started enabled=yes
-  when: install_ark.rc == 0
-
-- name: ARK server updated, restarting
-  service: name=arkmanager state=started enabled=yes
-  when: install_ark.rc == 191
 
 - include: set-firewall-module.yml
 


### PR DESCRIPTION
Hi,
Ansible failed with assert .
So I remove assert. then, it works well.
- My environments
  - Ubuntu 12.04 LTS
  - ansible 1.9.2
  - arkmanager v1.2
  - ARK Server version: 742434
- Debug log:

```
TASK: [kahn.arkservertools | debug var=install_ark] *************************** 
ok: [127.0.0.1] => {
    "var": {
        "install_ark": {
            "ansible_job_id": "308446411259.12273",
            "changed": true,
            "cmd": [
                "su",
                "-l",
                "steam",
                "-c",
                "arkmanager install"
            ],
            "delta": "0:25:33.627526",
            "end": "2015-08-21 14:41:52.717762",
            "finished": 1,
            "invocation": {
                "module_args": "jid=308446411259.12273",
                "module_name": "async_status"
            },
            "rc": 34,
            "start": "2015-08-21 14:16:19.090236",
            "stderr": ""
            "stdout_lines": [
                "Redirecting stderr to '/home/steam/Steam/logs/stderr.txt'",
                "Looks like steam didn't shutdown cleanly, scheduling immediate update check",
                "[  0%] Checking for available updates...",
                "[----] Verifying installation...",
                "Steam Console Client (c) Valve Corporation",
                "-- type 'quit' to exit --",
                "Loading Steam API...OK.",
                "",
                "Connecting anonymously to Steam Public...Logged in OK",
                "Waiting for license info...OK",
                "local (potentially out of sync) copy of roaming config loaded - 0 bytes.",
                " Update state (0x3) reconfiguring, progress: 0.00 (0 / 0)",
 ...
                "Success! App '376030' fully installed."
            ],
            "warnings": []
        }
    }
}

TASK: [kahn.arkservertools | Assert Install ARK dedicated server passed] ****** 
failed: [127.0.0.1] => {"assertion": "install_ark.rc in [ 0, 183, 191 ]", "evaluated_to": false, "failed": true}

FATAL: all hosts have already failed -- aborting
```
